### PR TITLE
Add commitment to document ethical impact of the work

### DIFF
--- a/charter.html
+++ b/charter.html
@@ -293,6 +293,7 @@
           <h3>
             Other Deliverables
           </h3>
+          <p>The Working Group will develop a <span id="ethical-issues">Working Group Note documenting ethical issues</span> associated with using Machine Learning on the Web, to help identify what mitigations its normative specifications should take into account.</p>
           <p>
             Other non-normative documents may be created such as:
           </p>
@@ -337,6 +338,9 @@
           Each specification should contain a section detailing all known
           security and privacy implications for implementers, Web authors, and
           end users.
+        </p>
+        <p>
+          Each specification should contain a section detailing ethical considerations describing how implementers and Web authors should mitigate risks associated with ethical issues, such as <a href="#ethical-issues">the ones the group will be documenting</a>.
         </p>
         <p>
           There should be testing plans for each specification, starting from


### PR DESCRIPTION
Based on input from AC review. Includes both a non-normative deliverable on ethical issues of using ML on the Web, and a commitment to document ethical considerations in specifications